### PR TITLE
Fix some build instructions in README.txt and makefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ running the following commands:
 # Remove other modules that may conflict
 module purge
 # Add matlab for simulation
-module load matlab
+module load matlab/2018b
 # add the most up-to-date version of python
-module load anaconda3/5.01
+module load anaconda3/5.0.1
 # add nvidia modules for GPU acceleration of the ML model
 module load cuda-toolkit/9.0.176
 module load cuDNN/9.0v7

--- a/makefile
+++ b/makefile
@@ -11,18 +11,21 @@ main: $B/Bridge_Pre_Allocation $B/SimulateDay
 	rm -f requiredMCRProducts.txt
 	rm -f readme.txt
 
-$B/SimulateDay: $S/SimulateDay.m
+$B/SimulateDay: $S/SimulateDay.m $B
 	$(CC) $(FLAGS) -m $< -o SimulateDay
 	rm -f run_SimulateDay.sh
 	mv SimulateDay $@
 
-$B/Bridge_Pre_Allocation: $S/Bridge_Pre_Allocation.m
+$B/Bridge_Pre_Allocation: $S/Bridge_Pre_Allocation.m $B
 	$(CC) $(FLAGS) -m $< -o Bridge_Pre_Allocation
 	rm -f run_Bridge_Pre_Allocation.sh
 	mv Bridge_Pre_Allocation $@
 
 lightClean:
 	rm -f mccExcludedFiles.log  requiredMCRProducts.txt readme.txt
+
+$B:
+	mkdir $B
 
 clean:
 	rm -rf bin/*


### PR DESCRIPTION
+ Previously make would not create the bin directory, now it does
+ Previously the module list had a typo for anaconda3/5.01 which should
  be anaconda3/5.0.1.  This has been corrected
+ There are mulitple version of matlab on palmetto, not all of them
  provide mcc, require a version which provides it explicitly.